### PR TITLE
Fix recorded step handling

### DIFF
--- a/board.py
+++ b/board.py
@@ -131,7 +131,10 @@ class Board:
         """
 
         if record_steps and _steps is None:
-            _steps = [[cell for cell in row] for row in self.grid]
+            # Start the step list with a deep copy of the initial grid so
+            # callers receive a sequence of full board states rather than a
+            # mix of rows and grids.
+            _steps = [[row[:] for row in self.grid]]
 
         def apply_determined():
             actions = []

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import time
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from board import Board
+from animation import animate_steps
+
+
+def test_animate_steps_no_errors(monkeypatch):
+    board = Board([[0]*9 for _ in range(9)])
+    solved, steps = board.solve(record_steps=True)
+
+    # Avoid clearing the terminal and sleeping during the test
+    monkeypatch.setattr('animation.os.system', lambda cmd: None)
+    monkeypatch.setattr('animation.time.sleep', lambda s: None)
+
+    animate_steps(steps, delay=0)

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -67,3 +67,14 @@ def test_solver_succeeds_and_board_representation():
         " ".join(str(c) for c in row) for row in EXPECTED_SOLUTION
     )
     assert str(board) == expected_str
+
+
+def test_record_steps_returns_sequence_of_grids():
+    board = Board(create_puzzle())
+    solved, steps = board.solve(record_steps=True)
+    assert isinstance(steps, list)
+    assert steps  # at least the initial board
+    for grid in steps:
+        assert isinstance(grid, list) and len(grid) == 9
+        for row in grid:
+            assert isinstance(row, list) and len(row) == 9


### PR DESCRIPTION
## Summary
- fix step recording to start with full grid state
- add regression tests for recorded steps
- test animate_steps function to avoid future errors

## Testing
- `pytest -q`